### PR TITLE
fix: rate is mutating the source params, causing incorrect results on limit_sigma

### DIFF
--- a/openskill/models/weng_lin/bradley_terry_full.py
+++ b/openskill/models/weng_lin/bradley_terry_full.py
@@ -652,11 +652,7 @@ class BradleyTerryFull:
             for team_index, team in enumerate(processed_result):
                 final_team = []
                 for player_index, player in enumerate(team):
-                    player_original = original_teams[team_index][player_index]
-                    if player.sigma <= player_original.sigma:
-                        player.sigma = player.sigma
-                    else:
-                        player.sigma = player_original.sigma
+                    player.sigma = min(player.sigma, original_teams[team_index][player_index].sigma)
                     final_team.append(player)
                 final_result.append(final_team)
         return final_result

--- a/openskill/models/weng_lin/bradley_terry_full.py
+++ b/openskill/models/weng_lin/bradley_terry_full.py
@@ -652,7 +652,9 @@ class BradleyTerryFull:
             for team_index, team in enumerate(processed_result):
                 final_team = []
                 for player_index, player in enumerate(team):
-                    player.sigma = min(player.sigma, original_teams[team_index][player_index].sigma)
+                    player.sigma = min(
+                        player.sigma, original_teams[team_index][player_index].sigma
+                    )
                     final_team.append(player)
                 final_result.append(final_team)
         return final_result

--- a/openskill/models/weng_lin/bradley_terry_full.py
+++ b/openskill/models/weng_lin/bradley_terry_full.py
@@ -588,7 +588,8 @@ class BradleyTerryFull:
                 )
 
         # Deep Copy Teams
-        original_teams = copy.deepcopy(teams)
+        original_teams = teams
+        teams = copy.deepcopy(original_teams)
 
         # Correct Sigma With Tau
         tau = tau if tau else self.tau

--- a/openskill/models/weng_lin/bradley_terry_part.py
+++ b/openskill/models/weng_lin/bradley_terry_part.py
@@ -657,7 +657,9 @@ class BradleyTerryPart:
             for team_index, team in enumerate(processed_result):
                 final_team = []
                 for player_index, player in enumerate(team):
-                    player.sigma = min(player.sigma, original_teams[team_index][player_index].sigma)
+                    player.sigma = min(
+                        player.sigma, original_teams[team_index][player_index].sigma
+                    )
                     final_team.append(player)
                 final_result.append(final_team)
         return final_result

--- a/openskill/models/weng_lin/bradley_terry_part.py
+++ b/openskill/models/weng_lin/bradley_terry_part.py
@@ -593,7 +593,8 @@ class BradleyTerryPart:
                 )
 
         # Deep Copy Teams
-        original_teams = copy.deepcopy(teams)
+        original_teams = teams
+        teams = copy.deepcopy(original_teams)
 
         # Correct Sigma With Tau
         tau = tau if tau else self.tau

--- a/openskill/models/weng_lin/bradley_terry_part.py
+++ b/openskill/models/weng_lin/bradley_terry_part.py
@@ -657,11 +657,7 @@ class BradleyTerryPart:
             for team_index, team in enumerate(processed_result):
                 final_team = []
                 for player_index, player in enumerate(team):
-                    player_original = original_teams[team_index][player_index]
-                    if player.sigma <= player_original.sigma:
-                        player.sigma = player.sigma
-                    else:
-                        player.sigma = player_original.sigma
+                    player.sigma = min(player.sigma, original_teams[team_index][player_index].sigma)
                     final_team.append(player)
                 final_result.append(final_team)
         return final_result

--- a/openskill/models/weng_lin/plackett_luce.py
+++ b/openskill/models/weng_lin/plackett_luce.py
@@ -588,7 +588,8 @@ class PlackettLuce:
                 )
 
         # Deep Copy Teams
-        original_teams = copy.deepcopy(teams)
+        original_teams = teams
+        teams = copy.deepcopy(original_teams)
 
         # Correct Sigma With Tau
         tau = tau if tau else self.tau

--- a/openskill/models/weng_lin/plackett_luce.py
+++ b/openskill/models/weng_lin/plackett_luce.py
@@ -652,11 +652,7 @@ class PlackettLuce:
             for team_index, team in enumerate(processed_result):
                 final_team = []
                 for player_index, player in enumerate(team):
-                    player_original = original_teams[team_index][player_index]
-                    if player.sigma <= player_original.sigma:
-                        player.sigma = player.sigma
-                    else:
-                        player.sigma = player_original.sigma
+                    player.sigma = min(player.sigma, original_teams[team_index][player_index].sigma)
                     final_team.append(player)
                 final_result.append(final_team)
         return final_result

--- a/openskill/models/weng_lin/plackett_luce.py
+++ b/openskill/models/weng_lin/plackett_luce.py
@@ -652,7 +652,9 @@ class PlackettLuce:
             for team_index, team in enumerate(processed_result):
                 final_team = []
                 for player_index, player in enumerate(team):
-                    player.sigma = min(player.sigma, original_teams[team_index][player_index].sigma)
+                    player.sigma = min(
+                        player.sigma, original_teams[team_index][player_index].sigma
+                    )
                     final_team.append(player)
                 final_result.append(final_team)
         return final_result

--- a/openskill/models/weng_lin/thurstone_mosteller_full.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_full.py
@@ -667,7 +667,9 @@ class ThurstoneMostellerFull:
             for team_index, team in enumerate(processed_result):
                 final_team = []
                 for player_index, player in enumerate(team):
-                    player.sigma = min(player.sigma, original_teams[team_index][player_index].sigma)
+                    player.sigma = min(
+                        player.sigma, original_teams[team_index][player_index].sigma
+                    )
                     final_team.append(player)
                 final_result.append(final_team)
         return final_result

--- a/openskill/models/weng_lin/thurstone_mosteller_full.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_full.py
@@ -667,11 +667,7 @@ class ThurstoneMostellerFull:
             for team_index, team in enumerate(processed_result):
                 final_team = []
                 for player_index, player in enumerate(team):
-                    player_original = original_teams[team_index][player_index]
-                    if player.sigma <= player_original.sigma:
-                        player.sigma = player.sigma
-                    else:
-                        player.sigma = player_original.sigma
+                    player.sigma = min(player.sigma, original_teams[team_index][player_index].sigma)
                     final_team.append(player)
                 final_result.append(final_team)
         return final_result

--- a/openskill/models/weng_lin/thurstone_mosteller_full.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_full.py
@@ -603,7 +603,8 @@ class ThurstoneMostellerFull:
                 )
 
         # Deep Copy Teams
-        original_teams = copy.deepcopy(teams)
+        original_teams = teams
+        teams = copy.deepcopy(original_teams)
 
         # Correct Sigma With Tau
         tau = tau if tau else self.tau

--- a/openskill/models/weng_lin/thurstone_mosteller_part.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_part.py
@@ -605,7 +605,8 @@ class ThurstoneMostellerPart:
                 )
 
         # Deep Copy Teams
-        original_teams = copy.deepcopy(teams)
+        original_teams = teams
+        teams = copy.deepcopy(original_teams)
 
         # Correct Sigma With Tau
         tau = tau if tau else self.tau
@@ -669,6 +670,7 @@ class ThurstoneMostellerPart:
                 final_team = []
                 for player_index, player in enumerate(team):
                     player_original = original_teams[team_index][player_index]
+                    player = copy.deepcopy(player)
                     if player.sigma <= player_original.sigma:
                         player.sigma = player.sigma
                     else:

--- a/openskill/models/weng_lin/thurstone_mosteller_part.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_part.py
@@ -669,7 +669,9 @@ class ThurstoneMostellerPart:
             for team_index, team in enumerate(processed_result):
                 final_team = []
                 for player_index, player in enumerate(team):
-                    player.sigma = min(player.sigma, original_teams[team_index][player_index].sigma)
+                    player.sigma = min(
+                        player.sigma, original_teams[team_index][player_index].sigma
+                    )
                     final_team.append(player)
                 final_result.append(final_team)
         return final_result

--- a/openskill/models/weng_lin/thurstone_mosteller_part.py
+++ b/openskill/models/weng_lin/thurstone_mosteller_part.py
@@ -669,12 +669,7 @@ class ThurstoneMostellerPart:
             for team_index, team in enumerate(processed_result):
                 final_team = []
                 for player_index, player in enumerate(team):
-                    player_original = original_teams[team_index][player_index]
-                    player = copy.deepcopy(player)
-                    if player.sigma <= player_original.sigma:
-                        player.sigma = player.sigma
-                    else:
-                        player.sigma = player_original.sigma
+                    player.sigma = min(player.sigma, original_teams[team_index][player_index].sigma)
                     final_team.append(player)
                 final_result.append(final_team)
         return final_result

--- a/tests/models/weng_lin/test_bradley_terry_full.py
+++ b/tests/models/weng_lin/test_bradley_terry_full.py
@@ -447,12 +447,12 @@ def test_rate_errors() -> None:
     assert winner.sigma == a.sigma
     assert loser.sigma == b.sigma
 
-    # Ensures sigma decreases
+    # Ensures sigma does not increase
     a = r()
     b = r()
     [[winner], [loser]] = model.rate([[a], [b]], tau=0.3, limit_sigma=True)
-    assert winner.sigma == a.sigma
-    assert loser.sigma == b.sigma
+    assert winner.sigma <= a.sigma
+    assert loser.sigma <= b.sigma
 
     # Test ValueError
     team_1 = [r()]

--- a/tests/models/weng_lin/test_bradley_terry_part.py
+++ b/tests/models/weng_lin/test_bradley_terry_part.py
@@ -450,12 +450,12 @@ def test_rate_errors() -> None:
     assert winner.sigma == a.sigma
     assert loser.sigma == b.sigma
 
-    # Ensures sigma decreases
+    # Ensures sigma does not increase
     a = r()
     b = r()
     [[winner], [loser]] = model.rate([[a], [b]], tau=0.3, limit_sigma=True)
-    assert winner.sigma == a.sigma
-    assert loser.sigma == b.sigma
+    assert winner.sigma <= a.sigma
+    assert loser.sigma <= b.sigma
 
     # Test ValueError
     team_1 = [r()]

--- a/tests/models/weng_lin/test_plackett_luce.py
+++ b/tests/models/weng_lin/test_plackett_luce.py
@@ -445,12 +445,12 @@ def test_rate_errors() -> None:
     assert winner.sigma == a.sigma
     assert loser.sigma == b.sigma
 
-    # Ensures sigma decreases
+    # Ensures sigma does not increase
     a = r()
     b = r()
     [[winner], [loser]] = model.rate([[a], [b]], tau=0.3, limit_sigma=True)
-    assert winner.sigma == a.sigma
-    assert loser.sigma == b.sigma
+    assert winner.sigma <= a.sigma
+    assert loser.sigma <= b.sigma
 
     # Test ValueError
     team_1 = [r()]

--- a/tests/models/weng_lin/test_thurstone_mosteller_full.py
+++ b/tests/models/weng_lin/test_thurstone_mosteller_full.py
@@ -451,15 +451,15 @@ def test_rate_errors() -> None:
     a = r(mu=40, sigma=3)
     b = r(mu=-20, sigma=3)
     [[winner], [loser]] = model.rate([[a], [b]], tau=0.3, limit_sigma=True)
-    assert winner.sigma == a.sigma
-    assert loser.sigma == b.sigma
+    assert winner.sigma <= a.sigma
+    assert loser.sigma <= b.sigma
 
-    # Ensures sigma decreases
+    # Ensures sigma does not increase
     a = r()
     b = r()
     [[winner], [loser]] = model.rate([[a], [b]], tau=0.3, limit_sigma=True)
-    assert winner.sigma == a.sigma
-    assert loser.sigma == b.sigma
+    assert winner.sigma <= a.sigma
+    assert loser.sigma <= b.sigma
 
     # Test ValueError
     team_1 = [r()]

--- a/tests/models/weng_lin/test_thurstone_mosteller_part.py
+++ b/tests/models/weng_lin/test_thurstone_mosteller_part.py
@@ -458,12 +458,12 @@ def test_rate_errors() -> None:
     assert winner.sigma == a.sigma
     assert loser.sigma == b.sigma
 
-    # Ensures sigma decreases
+    # Ensures sigma does not increase
     a = r()
     b = r()
     [[winner], [loser]] = model.rate([[a], [b]], tau=0.3, limit_sigma=True)
-    assert winner.sigma == a.sigma
-    assert loser.sigma == b.sigma
+    assert winner.sigma <= a.sigma
+    assert loser.sigma <= b.sigma
 
     # Test ValueError
     team_1 = [r()]


### PR DESCRIPTION
the is a smoking gun here should be seeing the unit test say `# Ensures sigma decreases`, and then immediately after assert that the sigma did not actually change. this assertion is wrong, but it covers up a critical problem.

recent changes in `rate` which cause it to mutate the input teams given. the following code will help to fix that, and it could be further optimized but it's important to get this math correct.

consider code that says

```python
for player_index, player in enumerate(team):
  player.sigma = 123
  final_team.append(player)
```

this will change player.sigma in `team` and then append that same player to `final_team`. it's important that we don't mutate the players input into the function.