### PR TITLE
build: configure test running in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}


### PR DESCRIPTION
Would you accept this? It configures pytest to run inside of vs-code if microsoft's python extension is installed. Alternatively I could just add `/.vscode` to .gitignore, or neither and just move this to my global config; i just figure committing this might help others get into the repo.

<img width="1576" alt="Screenshot 2024-09-21 at 18 55 08" src="https://github.com/user-attachments/assets/cade04cb-c57c-42f8-b1a6-692249ed8985">
