### PR TITLE
Fix Discord link typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ True
 # Support
 If you're struggling with any of the concepts, please search the discussions section to see if your question has already been answered.
 If you can't find an answer, please open a new [discussion](https://github.com/vivekjoshy/openskill.py/discussions) and we'll try to help you out.
-You can also get help from the official [Discord Server](https://discord.com/invite/4JNDeHMYkM>). If you have a feature request, or want to report
+You can also get help from the official [Discord Server](https://discord.com/invite/4JNDeHMYkM). If you have a feature request, or want to report
 a bug please create a new [issue](https://github.com/vivekjoshy/openskill.py/issues/new/choose) if one already doesn't exist.
 
 # References


### PR DESCRIPTION
<!--- Make sure to read the Contributing Guidelines:   --->
<!--- Follow PEP 257 and format with black on default settings. --->

## Description of Changes

Discord link was not working because of a trailing '>', remove it.

<!--- Explain what you've done and why --->




### Issue(s) Resolved

<!--- List the issue(s) below, in the form "Fixes #1234"; one per line --->

N/A

### Affirmation

By submitting this Pull Request or typing my (user)name below,
I affirm the [Developer Certificate of Origin](https://developercertificate.org)
with respect to all commits and content included in this PR,
and understand I am releasing the same under openskill.py's MIT license.

<!--- TYPE YOUR USER/NAME AFTER THE FOLLOWING: --->
I certify the above statement is true and correct: bemug

<!--- Thanks for your help making openskill.py better for everyone! --->
